### PR TITLE
createRT, renew token by RT (backend), refresh old token header

### DIFF
--- a/asura-backend/src/core/interfaces/auth.interface.ts
+++ b/asura-backend/src/core/interfaces/auth.interface.ts
@@ -1,0 +1,8 @@
+export interface DataStoredInToken {
+  id: string;
+}
+
+export interface TokenData {
+  token: string;
+  refreshToken: string;
+}

--- a/asura-backend/src/core/interfaces/index.ts
+++ b/asura-backend/src/core/interfaces/index.ts
@@ -2,3 +2,4 @@ import Route from "./routes.interfaces";
 import IPagination from "./pagination.interface";
 
 export { Route, IPagination };
+export * from "./auth.interface";

--- a/asura-backend/src/core/middleware/auth.middleware.ts
+++ b/asura-backend/src/core/middleware/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, response } from "express";
 
-import { DataStoredInToken } from "../../modules/auth/auth.interface";
+import { DataStoredInToken } from "../interfaces/auth.interface";
 import jwt from "jsonwebtoken";
 import Logger from "@core/utils/logger";
 
@@ -18,18 +18,25 @@ const authMiddleware = (
   try {
     const decodedToken = jwt.verify(
       token as string,
-      process.env.JWT_TOKEN_SECRET!
+      process.env.JWT_TOKEN_SECRET ?? ""
     ) as unknown;
 
     const user = decodedToken as DataStoredInToken;
 
     if (!res.locals.user) res.locals.user = { id: "" };
-
+    console.log("user", user);
     res.locals.user.id = user.id;
     next();
   } catch (error) {
-    Logger.error(`[ERROR] Msg: ${error}`);
-    res.status(401).json({ message: "Token is not valid" });
+    Logger.error(`[ERROR] Msg: ${token}`);
+    // Kiểm tra  error là object khác null và có 'name'
+    if (typeof error === "object" && error !== null && "name" in error) {
+      if (error.name == "TokenExpiredError") {
+        res.status(401).json({ message: "Token is expired" });
+      } else {
+        res.status(401).json({ message: "Token is not valid" });
+      }
+    }
   }
 };
 

--- a/asura-backend/src/core/utils/helpers.ts
+++ b/asura-backend/src/core/utils/helpers.ts
@@ -1,3 +1,39 @@
+import { DataStoredInToken, TokenData } from "@core/interfaces";
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+
 export const isEmptyObject = (obj: object): boolean => {
-    return !Object.keys(obj).length;//Co the dung luôn vào code nma ta lại thích tách ra ngô ra khoai :v
-}
+  return !Object.keys(obj).length; //Co the dung luôn vào code nma ta lại thích tách ra ngô ra khoai :v
+};
+
+export const randomTokenString = (): string => {
+  //random ra refresh token
+  return crypto.randomBytes(40).toString("hex");
+};
+
+export const createToken = (
+  userId: string,
+  refreshToken: string
+): TokenData => {
+  const dataInToken: DataStoredInToken = { id: userId };
+  const secret: string = process.env.JWT_TOKEN_SECRET ?? "";
+  const expiresIn = 3600;
+  return {
+    token: jwt.sign(dataInToken, secret, { expiresIn: expiresIn }),
+    refreshToken: refreshToken,
+  };
+};
+
+export const generateJwtToken = (
+  userId: string,
+  refreshToken: string
+): TokenData => {
+  console.log("userId", userId);
+  const dataInToken: DataStoredInToken = { id: userId };
+  const secret: string = process.env.JWT_TOKEN_SECRET ?? "";
+  const expiresIn = 60;
+  return {
+    token: jwt.sign(dataInToken, secret, { expiresIn: expiresIn }),
+    refreshToken: refreshToken,
+  };
+};

--- a/asura-backend/src/modules/auth/auth.controller.ts
+++ b/asura-backend/src/modules/auth/auth.controller.ts
@@ -1,14 +1,43 @@
 import { Request, Response, NextFunction } from "express";
 import UserService from "./auth.service";
 import LoginDto from "./auth.dto";
-import { TokenData } from "@modules/auth";
+import { AuthService, TokenData } from "@modules/auth";
 export default class AuthController {
   private userService = new UserService();
+  private authService = new AuthService();
   public login = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const model: LoginDto = req.body;
       const tokenData: TokenData = await this.userService.login(model); //Ở đây tokenData sẽ có kiểu TokenData nhưng ta ép kiểu thế kia nhìn nó tường minh hơn thôi
       res.status(200).json(tokenData);
+    } catch (error) {
+      next(error);
+    }
+  };
+  public refreshToken = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const refreshToken = req.body.refreshToken;
+      const tokenData: TokenData = await this.authService.refreshToken(
+        refreshToken
+      );
+      res.status(200).json(tokenData);
+    } catch (error) {
+      next(error);
+    }
+  };
+  public revokeToken = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const token = req.body.token;
+      await this.authService.revokeToken(token);
+      res.status(200);
     } catch (error) {
       next(error);
     }
@@ -19,9 +48,9 @@ export default class AuthController {
     next: NextFunction
   ) => {
     try {
-      const user = await this.userService.getCurrentLoginUser(
-        res.locals.user.id
-      ); //Ở đây tokenData sẽ có kiểu TokenData nhưng ta ép kiểu thế kia nhìn nó tường minh hơn thôi
+      const userId = res.locals.user.id;
+      console.log("userId", userId);
+      const user = await this.userService.getCurrentLoginUser(userId); //Ở đây tokenData sẽ có kiểu TokenData nhưng ta ép kiểu thế kia nhìn nó tường minh hơn thôi
       res.status(200).json(user);
     } catch (error) {
       next(error);

--- a/asura-backend/src/modules/auth/auth.interface.ts
+++ b/asura-backend/src/modules/auth/auth.interface.ts
@@ -1,7 +1,0 @@
-export interface DataStoredInToken{
-    id: string;
-}
-
-export interface TokenData{
-    token: string;
-}

--- a/asura-backend/src/modules/auth/auth.route.ts
+++ b/asura-backend/src/modules/auth/auth.route.ts
@@ -16,6 +16,15 @@ export default class AuthRoute implements Route {
       this.path,
       authMiddleware,
       this.authController.getCurrentUserLogin
-    ); //POST: http://localhost:5000/api/auth
+    ); //GET: http://localhost:5000/api/auth+x-auth-token
+    this.router.post(
+      this.path + "/refresh-token",
+      this.authController.refreshToken
+    );
+    this.router.post(
+      this.path + "/revoke-token",
+      authMiddleware,
+      this.authController.revokeToken
+    );
   }
 }

--- a/asura-backend/src/modules/auth/auth.service.ts
+++ b/asura-backend/src/modules/auth/auth.service.ts
@@ -5,26 +5,38 @@ import { HttpException } from "@core/exceptions";
 import bcryptjs from "bcryptjs";
 import jwt from "jsonwebtoken";
 import LoginDto from "./auth.dto";
+import { token } from "morgan";
+import { generateJwtToken, randomTokenString } from "@core/utils/helpers";
+import { IRefreshToken, RefreshTokenSchema } from "@modules/refresh_token";
+import Logger from "@core/utils/logger";
+import { RefreshTokenDocument } from "@modules/refresh_token/refresh_token_model";
+import { HydratedDocument } from "mongoose";
 class AuthService {
   public userSchema = UserSchema;
   public async login(model: LoginDto): Promise<TokenData> {
+    const user = await this.userSchema.findOne({ email: model.email });
     if (isEmptyObject(model)) {
       throw new HttpException(400, "Model is empty");
     }
+    if (user)
+      if (!user.password)
+        throw new HttpException(400, "User password is missing");
 
-    const user = await this.userSchema.findOne({ email: model.email });
     if (!user) {
       throw new HttpException(409, `Your email ${model.email} already exist. `);
     }
-    if (!user.password)
-      throw new HttpException(400, "User password is missing");
     const isMatchPassword = await bcryptjs.compare(
       model.password,
       user.password
     );
     if (!isMatchPassword)
       throw new HttpException(400, "Credential is not valid");
-    return this.createToken(user); //Sau cung thi return token
+    const refreshToken: HydratedDocument<IRefreshToken> =
+      await this.generateRefreshToken(user._id);
+    console.log("user._id", typeof user._id, user._id);
+    const jwtToken = generateJwtToken(user._id, refreshToken.token);
+    await refreshToken.save();
+    return jwtToken; //Sau cung thi return token
   }
 
   public async getCurrentLoginUser(userId: string): Promise<IUser> {
@@ -35,6 +47,27 @@ class AuthService {
     return user;
   }
 
+  public async refreshToken(token: string): Promise<TokenData> {
+    const refreshToken = await this.getRefreshTokenFromDb(token);
+    const user = refreshToken;
+    //thay RT cu va luu lai
+    const newRefreshToken = await this.generateRefreshToken(
+      user._id.toString()
+    );
+    refreshToken.revoked = new Date(Date.now());
+    refreshToken.replaceByToken = newRefreshToken.token;
+    await refreshToken.save();
+    await newRefreshToken.save();
+    return generateJwtToken(user.user._id.toString(), newRefreshToken.token);
+  }
+
+  public async revokeToken(token: string): Promise<void> {
+    const refreshToken = await this.getRefreshTokenFromDb(token);
+    //revoke token va luu no
+    refreshToken.revoked = new Date(Date.now());
+    await refreshToken.save();
+  }
+
   //Tao ham token data
   private createToken(user: IUser): TokenData {
     const dataInToken: DataStoredInToken = { id: user._id }; //Gan bien thi dung ngoac nhon
@@ -42,7 +75,27 @@ class AuthService {
     const expriesIn: number = 3600;
     return {
       token: jwt.sign(dataInToken, secret, { expiresIn: expriesIn }), //Den day phai bam, => add jsonwebtoken de no bam ra jwt token
+      refreshToken: "",
     };
+  }
+
+  private async generateRefreshToken(userId: string) {
+    //Tao RT het han 7 ngay
+    return new RefreshTokenSchema({
+      user: userId,
+      token: randomTokenString(),
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+  }
+
+  private async getRefreshTokenFromDb(refreshToken: string) {
+    const token = await RefreshTokenSchema.findOne({ token: refreshToken })
+      .populate("user")
+      .exec();
+    Logger.info(token);
+    if (!token || !token.isActive)
+      throw new HttpException(400, "Invalid refresh token");
+    return token;
   }
 }
 

--- a/asura-backend/src/modules/auth/index.ts
+++ b/asura-backend/src/modules/auth/index.ts
@@ -1,4 +1,7 @@
-import { DataStoredInToken, TokenData } from "./auth.interface";
+import {
+  DataStoredInToken,
+  TokenData,
+} from "../../core/interfaces/auth.interface";
 import AuthRoute from "./auth.route";
 import AuthService from "./auth.service";
 import AuthController from "./auth.controller";

--- a/asura-backend/src/modules/refresh_token/index.ts
+++ b/asura-backend/src/modules/refresh_token/index.ts
@@ -1,0 +1,3 @@
+import RefreshTokenSchema from "./refresh_token_model";
+import IRefreshToken from "./refresh_token_interface";
+export { RefreshTokenSchema, IRefreshToken };

--- a/asura-backend/src/modules/refresh_token/refresh_token_interface.ts
+++ b/asura-backend/src/modules/refresh_token/refresh_token_interface.ts
@@ -1,0 +1,16 @@
+import { Types } from "mongoose";
+
+export default interface IRefreshToken {
+  user: Types.ObjectId;
+  token: string;
+  expires: Date;
+  created: Date;
+  createdByIp?: string;
+  revoked?: Date;
+  revokedByIp?: string;
+  replaceByToken?: string;
+
+  // Virtuals
+  isExpired?: boolean;
+  isActive?: boolean;
+}

--- a/asura-backend/src/modules/refresh_token/refresh_token_model.ts
+++ b/asura-backend/src/modules/refresh_token/refresh_token_model.ts
@@ -1,0 +1,30 @@
+import mongoose, { Schema, HydratedDocument } from "mongoose";
+import IRefreshToken from "./refresh_token_interface";
+
+const RefreshTokenSchema = new Schema<IRefreshToken>({
+  user: { type: Schema.Types.ObjectId, ref: "user" },
+  token: String,
+  expires: Date,
+  created: { type: Date, default: Date.now },
+  createdByIp: String,
+  revoked: Date,
+  revokedByIp: String,
+  replaceByToken: String,
+});
+
+RefreshTokenSchema.virtual("isExpired").get(function (this: IRefreshToken) {
+  return Date.now() >= this.expires.getTime();
+});
+
+RefreshTokenSchema.virtual("isActive").get(function (
+  this: IRefreshToken & { isExpired: boolean }
+) {
+  return !this.revoked && !this.isExpired;
+});
+
+export type RefreshTokenDocument = HydratedDocument<IRefreshToken>;
+
+export default mongoose.model<IRefreshToken>(
+  "refreshToken",
+  RefreshTokenSchema
+);

--- a/asura-backend/src/modules/users/user.service.ts
+++ b/asura-backend/src/modules/users/user.service.ts
@@ -8,6 +8,8 @@ import bcryptjs from "bcryptjs";
 import IUser from "./user.interface";
 import jwt from "jsonwebtoken";
 import { IPagination } from "@core/interfaces";
+import { generateJwtToken, randomTokenString } from "@core/utils/helpers";
+import { RefreshTokenSchema } from "@modules/refresh_token";
 class UserService {
   public userSchema = UserSchema;
   public async createUser(model: RegisterDto): Promise<TokenData> {
@@ -34,7 +36,9 @@ class UserService {
       avatar: avatar,
       date: Date.now(),
     });
-    return this.createToken(createdUser); //Sau cung thi return token
+    const refreshToken = await this.generateRefreshToken(createdUser._id);
+    await refreshToken.save();
+    return generateJwtToken(createdUser._id, refreshToken.token); //Sau cung thi return token
   }
   public async updateUser(userId: string, model: RegisterDto): Promise<IUser> {
     if (isEmptyObject(model)) {
@@ -110,6 +114,7 @@ class UserService {
     const expriesIn: number = 3600;
     return {
       token: jwt.sign(dataInToken, secret, { expiresIn: expriesIn }), //Den day phai bam, => add jsonwebtoken de no bam ra jwt token
+      refreshToken: "",
     };
   }
 
@@ -165,6 +170,14 @@ class UserService {
     if (!result.acknowledged)
       throw new HttpException(409, "Your id is invalid");
     return result.deletedCount;
+  }
+  private async generateRefreshToken(userId: string) {
+    //Tao RT het han 7 ngay
+    return new RefreshTokenSchema({
+      user: userId,
+      token: randomTokenString(),
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
   }
 }
 

--- a/asura-frontend/src/helpers/api.ts
+++ b/asura-frontend/src/helpers/api.ts
@@ -1,7 +1,12 @@
 import axios from "axios";
-import { store } from "../store";
-import { logout } from "../store/account/actions";
-import { UnknownAction } from "redux";
+import { AppState, store } from "../store";
+import { useNavigate } from "react-router";
+import { urlConstants } from "../constants/url-constants";
+import {
+  REFRESH_TOKEN_FAILURE,
+  REFRESH_TOKEN_REQUEST,
+  REFRESH_TOKEN_SUCCESS,
+} from "../store/account/types";
 
 const api = axios.create({
   baseURL: `${process.env.REACT_APP_API_URL}`,
@@ -13,7 +18,8 @@ const api = axios.create({
 // Thêm interceptor để tự động gắn x-auth-token nếu có
 api.interceptors.request.use(
   (config) => {
-    const token = sessionStorage.getItem("token");
+    const currentState = store.getState() as AppState;
+    const token = currentState.account.token;
     if (token) {
       config.headers = config.headers || {};
       config.headers["x-auth-token"] = token;
@@ -29,8 +35,51 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     if (err.response && err.response.status === 401) {
-      // todo
-      store.dispatch(logout() as UnknownAction);
+      const originalRequest = err.config; //Lay url dang bi loi
+      const currentState = store.getState() as AppState;
+      const refreshToken = currentState.account.refreshToken;
+      console.log("41", refreshToken);
+      //Neu RT ma loi nua thi ra login luon
+      if (
+        err.response.status === 401 &&
+        originalRequest.url ===
+          `${process.env.REACT_APP_API_URL}/auth/refresh-token/`
+      ) {
+        const navigate = useNavigate();
+        navigate(urlConstants.LOGIN);
+        return Promise.reject(err);
+      }
+      if (refreshToken) {
+        store.dispatch({
+          type: REFRESH_TOKEN_REQUEST,
+        });
+        return api
+          .post("/auth/refresh-token", { refreshToken: refreshToken })
+          .then((response) => {
+            store.dispatch({
+              type: REFRESH_TOKEN_SUCCESS,
+              payload: {
+                token: response.data.token,
+                refreshToken: response.data.refreshToken,
+              },
+            });
+            //Ngay sau do set lai header dung cho viec request lan tiep
+            api.defaults.headers.common["x-auth-token"] = response.data.token;
+            originalRequest.headers["x-auth-token"] = response.data.token;
+            return api(originalRequest);
+          })
+          .catch((err) => {
+            store.dispatch({
+              type: REFRESH_TOKEN_FAILURE,
+              payload: { error: err },
+            });
+            console.log(err);
+          });
+      } else {
+        console.log("Refresh token not available");
+        const navigate = useNavigate();
+        navigate(urlConstants.LOGIN);
+      }
     }
     return Promise.reject(err);
   }

--- a/asura-frontend/src/pages/Sidebar/Sidebar.tsx
+++ b/asura-frontend/src/pages/Sidebar/Sidebar.tsx
@@ -31,7 +31,7 @@ export const Sidebar = () => {
     </div>
     {/* Nav Item - Pages Collapse Menu */}
     <li className="nav-item">
-      <a role='button' className={"nav-link"+(isCompCollapsed?" collapsed":"")} data-toggle="collapse" data-target="#collapseTwo" aria-expanded={isCompCollapsed?"true":"false"} aria-controls="collapseTwo" onClick={()=>setIsCompCollapsed(!isCompCollapsed)}>
+      <a href='/' className={"nav-link"+(isCompCollapsed?" collapsed":"")} data-toggle="collapse" data-target="#collapseTwo" aria-expanded={isCompCollapsed?"true":"false"} aria-controls="collapseTwo" onClick={(e)=>{e.preventDefault();setIsCompCollapsed(!isCompCollapsed)}}>
         <i className="fas fa-fw fa-cog" />
         <span>Interfaces</span>
       </a>
@@ -45,7 +45,7 @@ export const Sidebar = () => {
     </li>
     {/* Nav Item - Utilities Collapse Menu */}
     <li className="nav-item">
-      <a role='button' className={"nav-link"+(isUtilColl?" collapsed":"")} data-toggle="collapse" data-target="#collapseUtilities" aria-expanded={isUtilColl?"true":"false"} aria-controls="collapseUtilities" onClick={()=>setIsUtilColl(!isUtilColl)}>
+      <a href='/' className={"nav-link"+(isUtilColl?" collapsed":"")} data-toggle="collapse" data-target="#collapseUtilities" aria-expanded={isUtilColl?"true":"false"} aria-controls="collapseUtilities" onClick={(e)=>{e.preventDefault();setIsUtilColl(!isUtilColl)}}>
         <i className="fas fa-fw fa-wrench" />
         <span>Utilities</span>
       </a>

--- a/asura-frontend/src/pages/Topbar/Topbar.tsx
+++ b/asura-frontend/src/pages/Topbar/Topbar.tsx
@@ -58,7 +58,7 @@ export const Topbar = () => {
           </li>
           {/* Nav Item - Alerts */}
           <li className="nav-item dropdown no-arrow mx-1">
-            <a className={"nav-link dropdown-toggle"+(isAlertShow?" show":"")} id="alertsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={isAlertShow?"true":"false"} onClick={()=>setIsAlertShow(!isAlertShow)}>
+            <a href='/' className={"nav-link dropdown-toggle"+(isAlertShow?" show":"")} id="alertsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={isAlertShow?"true":"false"} onClick={(e)=>{e.preventDefault();setIsAlertShow(!isAlertShow)}}>
               <i className="fas fa-bell fa-fw" />
               {/* Counter - Alerts */}
               <span className="badge badge-danger badge-counter">3+</span>
@@ -106,7 +106,7 @@ export const Topbar = () => {
           </li>
           {/* Nav Item - Messages */}
           <li className={"nav-item dropdown no-arrow mx-1"+(isMesShow?" show":"")}>
-            <a className="nav-link dropdown-toggle" id="messagesDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={isMesShow?"true":"false"} onClick={()=>setIsMesShow(!isMesShow)}>
+            <a href='/' className="nav-link dropdown-toggle" id="messagesDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={isMesShow?"true":"false"} onClick={(e)=>{e.preventDefault();setIsMesShow(!isMesShow)}}>
               <i className="fas fa-envelope fa-fw" />
               {/* Counter - Messages */}
               <span className="badge badge-danger badge-counter">7</span>
@@ -166,7 +166,7 @@ export const Topbar = () => {
           <div className="topbar-divider d-none d-sm-block" />
           {/* Nav Item - User Information */}
           <li className={"nav-item dropdown no-arrow"+(isOptShow?" show":"")}>
-            <a className="nav-link dropdown-toggle" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={(isOptShow?"true":"false")}  onClick={()=>setIsOptShow(!isOptShow)}>
+            <a href='/' className="nav-link dropdown-toggle" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded={(isOptShow?"true":"false")}  onClick={(e)=>{e.preventDefault();setIsOptShow(!isOptShow)}}>
               <span className="mr-2 d-lg-inline text-gray-600 small font-weight-bold">{user?(user.first_name+" "+user.last_name):"a"}</span>
               <img className="img-profile rounded-circle" src={user?(user.avatar):undefined} alt=''/>
             </a>

--- a/asura-frontend/src/pages/Users/Users.tsx
+++ b/asura-frontend/src/pages/Users/Users.tsx
@@ -26,7 +26,6 @@ export const Users = () => {
 
   const onPageChanged = (pageNumber: number)=>{
     setCurrentPage(pageNumber);
-    const searchKeyword: string = sessionStorage.getItem('searchKeyword')??"";
   }
   const handleSelectedRow = (id: string)=>{
     let newSelectedItems = [...selectedItems];
@@ -73,10 +72,10 @@ export const Users = () => {
   {/* DataTales Example */}
   <div className="card shadow mb-4">
     <div className="card-header py-3 d-flex justify-content-between align-items-center">
-      <h6 className="m-0 font-weight-bold text-primary">{(sessionStorage.getItem('searchKeyword') && sessionStorage.getItem('searchKeyword') != "")
+      <h6 className="m-0 font-weight-bold text-primary">{(sessionStorage.getItem('searchKeyword') && sessionStorage.getItem('searchKeyword') !== "")
       ? `Search results for: ${sessionStorage.getItem('searchKeyword')}`:"User list"
       }
-    {(sessionStorage.getItem('searchKeyword') && sessionStorage.getItem('searchKeyword') != "") && (
+    {(sessionStorage.getItem('searchKeyword') && sessionStorage.getItem('searchKeyword') !== "") && (
       <button
         className="btn btn-sm btn-secondary ml-3"
         onClick={() => {dispatch(loadUsersPaging(1) as any); sessionStorage.removeItem('searchKeyword')}}

--- a/asura-frontend/src/store/account/actions.ts
+++ b/asura-frontend/src/store/account/actions.ts
@@ -30,6 +30,7 @@ export const login = (
 
     try {
       const response = await userService.login(email, password);
+      console.log(response);
       dispatch({
         type: LOGIN_SUCCESS,
         payload: response,

--- a/asura-frontend/src/store/account/reducer.ts
+++ b/asura-frontend/src/store/account/reducer.ts
@@ -8,12 +8,16 @@ import {
   LOGIN_FAILURE,
   LOGIN_REQUEST,
   LOGIN_SUCCESS,
+  REFRESH_TOKEN_FAILURE,
+  REFRESH_TOKEN_REQUEST,
+  REFRESH_TOKEN_SUCCESS,
 } from "./types";
 const initialState: AccountState = {
   user: null,
   loading: false,
   error: null,
   token: null,
+  refreshToken: null,
 };
 
 export const accountReducer = (
@@ -28,6 +32,8 @@ export const accountReducer = (
       return {
         ...state,
         loading: false,
+        token: null,
+        refreshToken: null,
         error: action.payload.error,
       };
     }
@@ -36,6 +42,7 @@ export const accountReducer = (
         ...state,
         loading: false,
         token: action.payload.token,
+        refreshToken: action.payload.refreshToken,
       };
     }
     case LOG_OUT: {
@@ -47,20 +54,13 @@ export const accountReducer = (
       };
     }
     case LOAD_CURRENT_LOGIN_USER_REQUEST: {
-      return { ...state, user: null, loading: true };
+      return { ...state, loading: true };
     }
     case LOAD_CURRENT_LOGIN_USER_SUCCESS: {
       return {
-        user: action.payload.user ?? {
-          _id: "",
-          first_name: "",
-          last_name: "",
-          email: "",
-          avatar: "",
-        },
+        ...state,
+        user: action.payload.user,
         loading: false,
-        error: null,
-        token: state.token,
       };
     }
     case LOAD_CURRENT_LOGIN_USER_FAILURE: {
@@ -70,8 +70,29 @@ export const accountReducer = (
         error: action.payload.error,
       };
     }
+    case REFRESH_TOKEN_FAILURE: {
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    }
+    case REFRESH_TOKEN_REQUEST: {
+      return {
+        ...state,
+        loading: true,
+      };
+    }
+    case REFRESH_TOKEN_SUCCESS: {
+      return {
+        ...state,
+        loading: false,
+        token: action.payload.token,
+        refreshToken: action.payload.refreshToken,
+      };
+    }
     default: {
-      return state; //Store se tu hung cai return (su thay doi)
+      return state;
     }
   }
 };

--- a/asura-frontend/src/store/account/types.ts
+++ b/asura-frontend/src/store/account/types.ts
@@ -8,6 +8,9 @@ export const LOAD_CURRENT_LOGIN_USER_SUCCESS =
 export const LOAD_CURRENT_LOGIN_USER_FAILURE =
   "LOAD CURRENT LOGIN USER FAILURE";
 export const LOG_OUT = "LOG_OUT";
+export const REFRESH_TOKEN_REQUEST = "REFRESH_TOKEN_REQUEST";
+export const REFRESH_TOKEN_SUCCESS = "REFRESH_TOKEN_SUCCESS";
+export const REFRESH_TOKEN_FAILURE = "REFRESH_TOKEN_FAILURE";
 //Chuan bi khai bao cac req va res
 export interface AuthenticatedUser {
   _id: string;
@@ -31,6 +34,7 @@ interface LoginSuccess {
   type: typeof LOGIN_SUCCESS;
   payload: {
     token: string;
+    refreshToken: string;
   };
 }
 
@@ -62,12 +66,32 @@ interface LoadCurrentLoginUserFailure {
     error: unknown;
   };
 }
+
+interface RefreshTokenRequest {
+  type: typeof REFRESH_TOKEN_REQUEST;
+}
+
+interface RefreshTokenSuccess {
+  type: typeof REFRESH_TOKEN_SUCCESS;
+  payload: {
+    token: string;
+    refreshToken: string;
+  };
+}
+
+interface RefreshTokenFailure {
+  type: typeof REFRESH_TOKEN_FAILURE;
+  payload: {
+    error: unknown;
+  };
+}
 //=> 1 action se co 2 p, type la hang so va payload la doi tuong
 export interface AccountState {
   user: AuthenticatedUser | null;
   loading: boolean;
   error: unknown;
   token: string | null;
+  refreshToken: string | null;
 }
 
 export type AccountActionTypes =
@@ -77,4 +101,7 @@ export type AccountActionTypes =
   | LoginFailure //De check strong type
   | LoadCurrentLoginUserRequest
   | LoadCurrentLoginUserSuccess
-  | LoadCurrentLoginUserFailure;
+  | LoadCurrentLoginUserFailure
+  | RefreshTokenFailure
+  | RefreshTokenRequest
+  | RefreshTokenSuccess;

--- a/asura-frontend/src/store/users/actions.ts
+++ b/asura-frontend/src/store/users/actions.ts
@@ -1,4 +1,4 @@
-import { AnyAction, Dispatch, UnknownAction } from "redux";
+import { Dispatch, UnknownAction } from "redux";
 import {
   ADD_USER_FAILURE,
   ADD_USER_REQUEST,


### PR DESCRIPTION
Đầu tiên, thêm RT vào tokendata, chỉnh lại hàm tạo jwt token chứa thêm RT, Tạo schema mongodb từ kiểu RT định nghĩa, lưu các ttin cần thiết lquan đến RT. Sửa tất cả các pthuc cũ dùng hàm tạo jwt token cũ, rồi thêm route mới ref token và rev-token, chỉnh lại middleware đi kèm, tạo thêm pthuc controller, service pvu route đó. Ở FE ta chỉnh lại hàm inceptor của api response, nếu response lỗi mà do token hết hạn, có RT ta tiến hành nạp mới RT, thay header chứa token mới hạn. RT cx cho vào redux store nên cx p chỉnh sửa các chỗ chứa RT (ở đây RT trong account=> sửa account types, actions, reducer.